### PR TITLE
Dash to Panel Ubuntu Icon Padding

### DIFF
--- a/extras/login-gnome-shell/ubuntu/gnome-shell.css
+++ b/extras/login-gnome-shell/ubuntu/gnome-shell.css
@@ -2295,6 +2295,18 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-radius: 9999px;
 }
 
+.dashtopanelMainPanel .show-apps .overview-icon {
+  background-color: #E95420;
+  border-radius: 9999px;
+  padding: 0.18em;
+  margin-right: 0.18em;
+  margin-left: 0.18em;
+}
+
+.dashtopanelMainPanel .show-apps .overview-icon, .dashtopanelMainPanel .show-apps:active .overview-icon, .dashtopanelMainPanel .show-apps:checked .overview-icon {
+  background-color: #ce4414 !important;
+}
+
 #dashtodockContainer.extended .show-apps .overview-icon {
   border-radius: 0px;
   background-color: transparent !important;


### PR DESCRIPTION
Added red circle around Ubuntu icon when using Dash to Panel extension, similar to the original version of the theme. Modified in such a way that Panel Size < 48px still displays circle (circle was distorted in previous versions on smaller Panel Size).

![screenshot from 2017-07-26 22-32-58](https://user-images.githubusercontent.com/7206237/28643562-8a86c8c4-7256-11e7-8f45-ae1fc0bd2362.png)
![screenshot from 2017-07-26 22-33-25](https://user-images.githubusercontent.com/7206237/28643564-8a87a38e-7256-11e7-8692-7536a1207b83.png)
![screenshot from 2017-07-26 22-33-56](https://user-images.githubusercontent.com/7206237/28643566-8a8be26e-7256-11e7-97ff-6de1fef970aa.png)
![screenshot from 2017-07-26 22-34-27](https://user-images.githubusercontent.com/7206237/28643565-8a87dc6e-7256-11e7-8245-2d4b69ac83ab.png)
![screenshot from 2017-07-26 22-34-43](https://user-images.githubusercontent.com/7206237/28643563-8a872b7a-7256-11e7-9cff-bd0baf7b9537.png)
